### PR TITLE
DM-18520 ATPointing + ATAOS integration test

### DIFF
--- a/tests/fake_controllers/fake_athexapod.py
+++ b/tests/fake_controllers/fake_athexapod.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python
+
+"""
+A basic script to emulate the athexapod for integration tests.
+"""
+
+import asyncio
+
+from lsst.ts.salobj import Controller
+import SALPY_ATHexapod
+
+
+async def fake_move_to_position(id_data):
+    print("**********")
+    for axis in f'xyzuvw':
+        print(f"Moving {axis}: {getattr(id_data.data, axis)}")
+        await asyncio.sleep(0.5)
+    print("**********")
+
+
+if __name__ == "__main__":
+
+    print("Starting Controller")
+    athex = Controller(SALPY_ATHexapod)
+    print("Adding callback")
+    athex.cmd_moveToPosition.callback = fake_move_to_position
+    print("Run Controller forever")
+    asyncio.get_event_loop().run_forever()

--- a/tests/fake_controllers/fake_atpneumatics.py
+++ b/tests/fake_controllers/fake_atpneumatics.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python
+
+"""
+A basic script to emulate the ATPneumatic for integration tests.
+"""
+
+import asyncio
+
+from lsst.ts.salobj import Controller
+import SALPY_ATPneumatics
+
+
+async def fake_m1SetPressure(id_data):
+    print("**********")
+    print(f"Seeting m1 pressure to {id_data.data.pressure}")
+    await asyncio.sleep(0.5)
+    print("**********")
+
+
+async def fake_m2SetPressure(id_data):
+    print("**********")
+    print(f"Seeting m2 pressure to {id_data.data.pressure}")
+    await asyncio.sleep(0.5)
+    print("**********")
+
+
+if __name__ == "__main__":
+
+    print("Starting Controller")
+    atpne = Controller(SALPY_ATPneumatics)
+    print("Adding callback")
+    atpne.cmd_m1SetPressure.callback = fake_m1SetPressure
+    atpne.cmd_m2SetPressure.callback = fake_m2SetPressure
+    print("Run Controller forever")
+    asyncio.get_event_loop().run_forever()


### PR DESCRIPTION
Adds some new functionality to improve interface between ataos and commanded components.
Implements `correction_loop`, a coroutine that runs whenever the CSC is enable and will apply the enabled corrections.
Adds fake_athexapod and fake_atpneumatics to emulate the behavior of those components for integration test purposes.