### PR TITLE
Modified to force publishing of correction events for all filter/grat…

### DIFF
--- a/python/lsst/ts/ataos/__init__.py
+++ b/python/lsst/ts/ataos/__init__.py
@@ -19,10 +19,10 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-from .ataos_csc import *
-from .model import Model
-
 try:
     from .version import *
 except ImportError:
     __version__ = "?"
+
+from .ataos_csc import *
+from .model import Model

--- a/python/lsst/ts/ataos/ataos_csc.py
+++ b/python/lsst/ts/ataos/ataos_csc.py
@@ -2008,15 +2008,6 @@ class ATAOS(ConfigurableCsc):
                 f"Focus residuals are: {self.focus_offset_yet_to_be_applied}"
             )
 
-            # # Always will be true - FIXME
-            # found a case where if the hexapod correction is too small and
-            # doesn't get applied then this may not always be true.
-            # if (
-            #     np.max(np.abs(self.pointing_offsets_yet_to_be_applied))
-            #     <= 1e-12
-            #     or abs(self.focus_offset_yet_to_be_applied) <= 1e-12
-            # ):
-
             # Publish Event saying corrections are completed
             self.evt_atspectrographCorrectionCompleted.set_put(
                 focusOffset=_offset_value,

--- a/python/lsst/ts/ataos/ataos_csc.py
+++ b/python/lsst/ts/ataos/ataos_csc.py
@@ -138,6 +138,13 @@ class ATAOS(ConfigurableCsc):
         self.focus_offset_yet_to_be_applied = 0.0
         self.pointing_offsets_yet_to_be_applied = np.zeros((2))  # in arcsec
 
+        # Counter for how many loops through spectrograph correction are
+        # required. This is needed to satisfy race conditions that are not
+        # accounted for if using a boolean. This originates from the ATAOS
+        # always needing to publish events for filter/grating/wavelength
+        # changes, even when no actual change is required.
+        self.atspectrograph_corrections_required = 0
+
         # Add required callbacks for ATCamera
         self.camera.evt_shutterDetailedState.callback = self.shutter_monitor_callback
 
@@ -452,7 +459,7 @@ class ATAOS(ConfigurableCsc):
         # ATAOS was not monitoring the spectrograph when in the standby state
         # the offsets are made relative to nothing being in the beam
 
-        if filter_data is not None:
+        if filter_data is not None and disperser_data is not None:
             self.focus_offset_per_category["filter"] = filter_data.focusOffset
             self.focus_offset_yet_to_be_applied += filter_data.focusOffset
             self.pointing_offsets_per_category["filter"] = np.array(
@@ -466,7 +473,9 @@ class ATAOS(ConfigurableCsc):
                 filter_data.centralWavelength
             )
 
-        if disperser_data is not None:
+            # Add a spectrograph correction loop so the offsets are applied
+            self.atspectrograph_corrections_required += 1
+
             self.focus_offset_per_category["disperser"] = disperser_data.focusOffset
             self.focus_offset_yet_to_be_applied += disperser_data.focusOffset
             self.pointing_offsets_per_category["disperser"] = np.array(
@@ -1085,6 +1094,7 @@ class ATAOS(ConfigurableCsc):
         self.publish_enable_corrections()
 
     async def do_setWavelength(self, id_data):
+
         """Set wavelength to optimize focus when being used with the
         LATISS spectrograph. This must only be used
         when the spectrograph is being used (glass optics are in the beam).
@@ -1149,6 +1159,9 @@ class ATAOS(ConfigurableCsc):
         # Grab the asyncio lock when applying the correction
 
         async with self.correction_loop_lock:
+            self.log.debug(
+                "Compensating for focus difference due to change in wavelength."
+            )
 
             # must subtract whatever chromatic offset might already be in place
             _chromatic_offset = (
@@ -1160,6 +1173,9 @@ class ATAOS(ConfigurableCsc):
 
             self.focus_offset_per_category["total"] += _chromatic_offset
             self.focus_offset_per_category["wavelength"] = _chromatic_offset
+
+            # add a correction cycle to make the wavelength change
+            self.atspectrograph_corrections_required += 1
 
         # Perform one correction loop before handing back
         # Wait for correction to be applied - should be fast unless large
@@ -1485,6 +1501,8 @@ class ATAOS(ConfigurableCsc):
         self.log.info(
             "Caught ATSpectrograph filter change, calculating correction offsets"
         )
+        # Add a correction cycle to accomodate the change
+        self.atspectrograph_corrections_required += 1
         # Relative offset are to be applied to the model
         # so therefore we need to subtract offset already in place for the
         # previous filter, including the wavelength offset setting
@@ -1536,6 +1554,8 @@ class ATAOS(ConfigurableCsc):
         self.log.info(
             "Caught ATSpectrograph disperser change, calculating correction offsets"
         )
+        # Add a correction loop cycle
+        self.atspectrograph_corrections_required += 1
         _offset_to_apply = (
             data.focusOffset - self.focus_offset_per_category["disperser"]
         )
@@ -1758,18 +1778,20 @@ class ATAOS(ConfigurableCsc):
                 ):
                     self.log.debug(
                         f"Set value ({set_value}) and current value ({current}) "
-                        f"inside tolerance ({tolerance}) fox axis {axis}. Ignoring."
+                        f"inside tolerance ({tolerance}) for axis {axis}. Ignoring."
                     )
                     continue
                 else:
                     self.log.debug(
-                        f"Set value for axis {axis} above threshold. Applying correction."
+                        f"Set value for axis {axis} exceeds minimal threshold "
+                        f"required to apply correction. Applying correction."
                     )
                     apply_correction = True
                     break
 
             if not apply_correction:
                 self.log.debug("All hexapod corrections inside tolerance. Skipping...")
+                # FIXME: Bit should be flipped back before returning
                 return
 
             evt_start_attr.set(elevation=elevation, azimuth=azimuth, **hexapod)
@@ -1795,7 +1817,8 @@ class ATAOS(ConfigurableCsc):
 
     async def set_atspectrograph_corrections(self, azimuth, elevation):
         """Utility to apply hexapod and/or pointing corrections based on
-         the ATSpectrograph configuration.
+         the ATSpectrograph configuration. This gets called as part of
+         the regular control loop.
 
         Parameters
         ----------
@@ -1805,11 +1828,47 @@ class ATAOS(ConfigurableCsc):
 
         Can only be applied if hexapod correction is also applied
         """
-        self.log.debug("At the beginning of set_atspectrograph_corrections")
+        self.log.debug(
+            f"At the beginning of set_atspectrograph_corrections with "
+            f"{self.atspectrograph_corrections_required} correction "
+            f"loops required. "
+        )
 
-        if self.can_move():
-            # publish new detailed state
-            self.log.debug("Applying Spectrograph Corrections, if required")
+        # The following warnings should never occur but are here to help
+        # troubleshoot the issue should it arise.
+        if (
+            self.atspectrograph_corrections_required == 0
+            and abs(self.focus_offset_yet_to_be_applied) >= 1e-12
+        ):
+            self.log.warning(
+                f"No atspectrograph corrections loaded but focus_offsets "
+                f"of {self.self.pointing_offsets_yet_to_be_applied} are "
+                f"non-zero and above the numerical noise floor"
+            )
+        if (
+            self.atspectrograph_corrections_required == 0
+            and np.max(np.abs(self.pointing_offsets_yet_to_be_applied)) >= 1e-12
+        ):
+            self.log.warning(
+                "No atspectrograph corrections loaded but pointing_offsets of"
+                f" {self.pointing_offsets_yet_to_be_applied} are non-zero and"
+                f" above the numerical noise floor"
+            )
+
+        # if self.can_move() and
+        # (self.atspectrograph_corrections_required != 0):
+        # Ideally, only the check against can_move and
+        # atspectrograph_corrections_required should be necessary, however
+        # leaving the others in and will search the logs for the above
+        # warning messages just in case a bug exists.
+        if self.can_move() and (
+            np.max(np.abs(self.pointing_offsets_yet_to_be_applied)) >= 1e-12
+            or abs(self.focus_offset_yet_to_be_applied) >= 1e-12
+            or self.atspectrograph_corrections_required != 0
+        ):
+            self.log.debug(
+                "Applying Spectrograph Corrections due to filter/grating/wavelength change"
+            )
 
             status_bit = DetailedState.ATSPECTROGRAPH
             _offset_value = 0.0
@@ -1825,40 +1884,44 @@ class ATAOS(ConfigurableCsc):
             # applied to the hexapod anyways, so any offset 10x smaller
             # than that is surely noise.
 
+            self.log.debug(
+                f"Applying focus offset of {self.focus_offset_yet_to_be_applied} "
+                "in correction loop due to filter "
+                "and/or disperser changes."
+            )
+            # add the offset, then reset the value
+            # using subtraction here to avoid a possible race condition
+            # note that self.focus_offset_yet_to_be_applied is a value
+            # not an object so no deepcopy is required
             if abs(self.focus_offset_yet_to_be_applied) > abs(
                 self.correction_tolerance["z"] / 10
             ):
-                self.log.debug(
-                    f"Applying focus offset of {self.focus_offset_yet_to_be_applied} "
-                    "in correction loop due to filter "
-                    "and/or disperser changes."
-                )
-                # add the offset, then reset the value
-                # using subtraction here to avoid a possible race condition
-                # note that self.focus_offset_yet_to_be_applied is a value
-                # not an object so no deepcopy is required
                 _offset_value = self.focus_offset_yet_to_be_applied
                 self.model.add_offset("z", _offset_value)
                 self.focus_offset_yet_to_be_applied -= _offset_value
-                # publish events with new offsets
-                self.evt_correctionOffsets.set_put(
-                    **self.model.offset, force_output=True
-                )
                 # Do accounting to republish total offset and others that were
                 # set in the callbacks
                 self.focus_offset_per_category["total"] = self.model.offset["z"]
-                self.evt_focusOffsetSummary.set_put(
-                    **self.focus_offset_per_category, force_output=True
+            else:
+                self.log.debug(
+                    "Focus offset less than tolerance for "
+                    "adjustment. Passing without correcting"
                 )
-                await asyncio.sleep(0)
+
+            # publish events with new offsets, even if unchanged
+            self.evt_correctionOffsets.set_put(**self.model.offset, force_output=True)
+            self.evt_focusOffsetSummary.set_put(
+                **self.focus_offset_per_category, force_output=True
+            )
+            await asyncio.sleep(0)
 
             # Now do pointing
             if np.max(np.abs(self.pointing_offsets_yet_to_be_applied)) > abs(
                 _pointing_tolerance
             ):
                 self.log.info(
-                    f"Applying pointing offset of [X,Y]={self.pointing_offsets_yet_to_be_applied} "
-                    "in correction loop due to filter "
+                    f"Required pointing offset of [X,Y]={self.pointing_offsets_yet_to_be_applied} "
+                    "arcsec in correction loop due to filter "
                     "and/or disperser changes."
                 )
                 _pointing_offsets = copy.deepcopy(
@@ -1867,8 +1930,13 @@ class ATAOS(ConfigurableCsc):
             elif _offset_value:
                 # No offsets above thresholds, so just return
                 self.log.debug(
-                    "Focus and pointing offsets below tolerances. Passing without correcting"
+                    "Focus and pointing offsets less than tolerance required "
+                    "for adjustment. Passing without correcting"
                 )
+
+            # Now apply any required corrections and publish events
+            # This is required even if no focus or pointing changes are above
+            # the thresholds
 
             # Corrections required, so flip the bit on the detailed state
             self.detailed_state = self.detailed_state ^ status_bit
@@ -1878,55 +1946,86 @@ class ATAOS(ConfigurableCsc):
 
             # send out even saying correction is started
             self.evt_atspectrographCorrectionStarted.set_put(
-                focusOffset=_offset_value, pointingOffsets=_pointing_offsets
+                focusOffset=_offset_value,
+                pointingOffsets=_pointing_offsets,
+                force_output=True,
             )
 
-            try:
-                # Don't need a tolerance since these values only get set if
-                # they meet a tolerance already
-                if abs(_offset_value):
-                    self.log.debug("Applying focus correction with hexapod")
-                    await self.set_hexapod(azimuth, elevation)
-
-                if np.max(abs(_pointing_offsets)):
-                    self.log.debug(
-                        "Applying pointing correction _pointing_offsets"
-                        f" = {_pointing_offsets} with atcs"
-                    )
-                    # apply offsets relative to what is already there
-                    await self.atcs.offset_xy(
-                        _pointing_offsets[0],
-                        _pointing_offsets[1],
-                        relative=True,
-                        persistent=True,
-                    )
-                    await asyncio.sleep(0)
-                    # update accounting and remove the already applied offsets
-                    self.pointing_offsets_per_category["total"] += _pointing_offsets
-                    self.pointing_offsets_yet_to_be_applied -= _pointing_offsets
-
-                    self.log.debug(
-                        "new value of pointing_offsets_per_category['total'] is"
-                        f" {self.pointing_offsets_per_category['total']}"
-                    )
-                    self.evt_pointingOffsetSummary.set_put(
-                        total=self.pointing_offsets_per_category["total"],
-                        filter=self.pointing_offsets_per_category["filter"],
-                        disperser=self.pointing_offsets_per_category["disperser"],
-                    )
-
-            except Exception as e:
-                self.log.exception(
-                    f"Failed to apply spectrograph pointing offsets of {_pointing_offsets} or "
-                    f"failed to apply focus (hexapod offset) of : {_offset_value}"
+            # Apply focus correction if above tolerance
+            if abs(_offset_value):
+                self.log.debug(
+                    f"Applying focus correction {_offset_value}" " with hexapod"
                 )
-                raise e
-            finally:
-                self.evt_atspectrographCorrectionCompleted.set_put(
-                    focusOffset=_offset_value, pointingOffsets=_pointing_offsets
+                await self.set_hexapod(azimuth, elevation)
+
+            # Apply pointing correction if above tolerance
+            # note that the comparison to zero should not be an issue as
+            # it's explicitly set to zero then only changed if
+            # the tolerance evaluation done above is satisfied.
+            if np.max(abs(_pointing_offsets)) > 0:
+                self.log.debug(
+                    "Applying pointing correction _pointing_offsets"
+                    f" = {_pointing_offsets} with atcs"
                 )
-                # correction completed... flip bit on detailedState
-                self.detailed_state = self.detailed_state ^ status_bit
+                # apply offsets relative to what is already there
+                await self.atcs.offset_xy(
+                    _pointing_offsets[0],
+                    _pointing_offsets[1],
+                    relative=True,
+                    persistent=True,
+                )
+                await asyncio.sleep(0)
+                # update accounting and remove the already applied offsets
+                self.pointing_offsets_per_category["total"] += _pointing_offsets
+                self.pointing_offsets_yet_to_be_applied -= _pointing_offsets
+
+                self.log.debug(
+                    "new value of pointing_offsets_per_category['total'] is"
+                    f" {self.pointing_offsets_per_category['total']}"
+                )
+            # Publish pointing summary
+            self.evt_pointingOffsetSummary.set_put(
+                total=self.pointing_offsets_per_category["total"],
+                filter=self.pointing_offsets_per_category["filter"],
+                disperser=self.pointing_offsets_per_category["disperser"],
+                force_output=True,
+            )
+
+            # Should only publish correction completed if no further
+            # corrections are required
+            self.atspectrograph_corrections_required -= 1
+            self.log.debug(
+                "Corrections completed?"
+                f"Pointing residuals zero?: "
+                f"{np.max(np.abs(self.pointing_offsets_yet_to_be_applied)) <= 1e-12}, "
+                f"Focus residuals zero? {abs(self.focus_offset_yet_to_be_applied) <= 1e-12}, "
+                f"Required Correction loops remaining = {self.atspectrograph_corrections_required}"
+            )
+            self.log.debug(
+                f"Pointing residuals are: {self.pointing_offsets_yet_to_be_applied}"
+            )
+            self.log.debug(
+                f"Focus residuals are: {self.focus_offset_yet_to_be_applied}"
+            )
+
+            # # Always will be true - FIXME
+            # found a case where if the hexapod correction is too small and
+            # doesn't get applied then this may not always be true.
+            # if (
+            #     np.max(np.abs(self.pointing_offsets_yet_to_be_applied))
+            #     <= 1e-12
+            #     or abs(self.focus_offset_yet_to_be_applied) <= 1e-12
+            # ):
+
+            # Publish Event saying corrections are completed
+            self.evt_atspectrographCorrectionCompleted.set_put(
+                focusOffset=_offset_value,
+                pointingOffsets=_pointing_offsets,
+                force_output=True,
+            )
+            # correction completed for this iteration,
+            # flip bit on detailedState
+            self.detailed_state = self.detailed_state ^ status_bit
 
     @staticmethod
     def get_config_pkg():
@@ -1987,6 +2086,8 @@ class ATAOS(ConfigurableCsc):
             f"Caught a new atspectrograph summary state {self.atspectrograph_summary_state!r},"
             " resetting filter/disperser offsets"
         )
+        # Add correction cycles so new corrections will be applied
+        self.atspectrograph_corrections_required = 2  # one for focus, one for pointing
         # remove offsets from previous spectrograph setup
         self.focus_offset_yet_to_be_applied = -self.focus_offset_per_category["filter"]
         self.focus_offset_per_category["filter"] = 0.0
@@ -2061,7 +2162,7 @@ class ATAOS(ConfigurableCsc):
                 else:
                     raise e
 
-    def fault(self, code=None, report=""):
+    def fault(self, code=None, report="", traceback=""):
         """Enter the fault state.
 
         Subclass parent method to disable corrections in the wait to FAULT
@@ -2095,7 +2196,7 @@ class ATAOS(ConfigurableCsc):
 
         self.publish_enable_corrections()
 
-        super().fault(code=code, report=report)
+        super().fault(code=code, report=report, traceback=traceback)
 
     def pneumatics_ss_callback(self, data):
         """Callback to monitor summary state from atpneumatics.

--- a/tests/test_csc.py
+++ b/tests/test_csc.py
@@ -700,15 +700,6 @@ class TestCSC(unittest.TestCase):
                     0.0,
                 )
 
-                # Send to disabled state
-                await harness.aos_remote.cmd_disable.start()
-
-                # Verify mirror is lowered when transitioning from ENABLED
-                # to DISABLED since corrections are enabled
-                # FIXME: DM-28681 - verify called with pressure=0
-                self.assertTrue(harness.pnematics.cmd_m1SetPressure.callback.called)
-                self.assertTrue(harness.pnematics.cmd_m2SetPressure.callback.called)
-
         # # Run for unspecified location
         asyncio.get_event_loop().run_until_complete(doit())
 

--- a/tests/test_csc.py
+++ b/tests/test_csc.py
@@ -310,7 +310,7 @@ class TestCSC(unittest.TestCase):
                 )
 
                 harness.aos_remote.evt_detailedState.callback = Mock(wraps=callback)
-                harness.atptg.cmd_offsetAzEl.callback = Mock(
+                harness.atptg.cmd_poriginOffset.callback = Mock(
                     wraps=mount_offset_callback
                 )
 
@@ -370,7 +370,10 @@ class TestCSC(unittest.TestCase):
                     timeout=STD_TIMEOUT
                 )
 
-                logger.debug("Send applyCorrection command")
+                logger.debug(
+                    "Send applyCorrection command which will now "
+                    "work because corrections are disabled"
+                )
                 azimuth = np.random.uniform(0.0, 360.0)
                 # make sure it is never zero because np.random.uniform
                 # is [min, max)
@@ -381,6 +384,7 @@ class TestCSC(unittest.TestCase):
                 logger.debug(
                     "Test that the hexapod won't move if there's an exposure happening"
                 )
+                logger.debug(f"while_exposing is set to {while_exposing}")
                 if while_exposing:
                     shutter_state_topic = (
                         harness.camera.evt_shutterDetailedState.DataType()
@@ -404,10 +408,10 @@ class TestCSC(unittest.TestCase):
                 harness.pnematics.cmd_m2SetPressure.callback.assert_called()
                 if while_exposing:
                     harness.hexapod.cmd_moveToPosition.callback.assert_not_called()
-                    harness.atptg.cmd_offsetAzEl.callback.assert_not_called()
+                    harness.atptg.cmd_poriginOffset.callback.assert_not_called()
                 else:
                     harness.hexapod.cmd_moveToPosition.callback.assert_called()
-                    harness.atptg.cmd_offsetAzEl.callback.assert_called()
+                    harness.atptg.cmd_poriginOffset.callback.assert_called()
 
                 harness.aos_remote.evt_detailedState.callback.assert_called()
 
@@ -681,6 +685,26 @@ class TestCSC(unittest.TestCase):
 
                 # Verify mirror is lowered when transitioning from ENABLED
                 # to DISABLED since corrections are enabled
+                # this is done by sending a pressure of zero
+
+                self.assertEqual(
+                    (harness.pnematics.cmd_m1SetPressure.callback.call_args[0])[
+                        0
+                    ].pressure,
+                    0.0,
+                )
+                self.assertEqual(
+                    (harness.pnematics.cmd_m2SetPressure.callback.call_args[0])[
+                        0
+                    ].pressure,
+                    0.0,
+                )
+
+                # Send to disabled state
+                await harness.aos_remote.cmd_disable.start()
+
+                # Verify mirror is lowered when transitioning from ENABLED
+                # to DISABLED since corrections are enabled
                 # FIXME: DM-28681 - verify called with pressure=0
                 self.assertTrue(harness.pnematics.cmd_m1SetPressure.callback.called)
                 self.assertTrue(harness.pnematics.cmd_m2SetPressure.callback.called)
@@ -734,7 +758,7 @@ class TestCSC(unittest.TestCase):
                     wraps=hexapod_move_callback
                 )
                 harness.aos_remote.evt_detailedState.callback = Mock(wraps=callback)
-                harness.atptg.cmd_offsetAzEl.callback = Mock(
+                harness.atptg.cmd_poriginOffset.callback = Mock(
                     wraps=mount_offset_callback
                 )
 
@@ -812,6 +836,8 @@ class TestCSC(unittest.TestCase):
                     # flush these to be sure the grab the proper one below
                     harness.aos_remote.evt_correctionOffsets.flush()
                     harness.aos_remote.evt_focusOffsetSummary.flush()
+                    harness.aos_remote.evt_atspectrographCorrectionStarted.flush()
+                    harness.aos_remote.evt_atspectrographCorrectionCompleted.flush()
 
                     harness.atspectrograph.evt_reportedFilterPosition.set_put(
                         name=filter_name,
@@ -825,6 +851,19 @@ class TestCSC(unittest.TestCase):
                         pointingOffsets=disperser_pointing_offsets,
                     )
 
+                logger.debug(
+                    "Make sure spectrograph corrections have not "
+                    "been applied, so this should fail"
+                )
+                with self.assertRaises(asyncio.TimeoutError):
+                    await harness.aos_remote.evt_atspectrographCorrectionStarted.next(
+                        timeout=STD_TIMEOUT, flush=False
+                    )
+                with self.assertRaises(asyncio.TimeoutError):
+                    await harness.aos_remote.evt_atspectrographCorrectionCompleted.next(
+                        timeout=STD_TIMEOUT, flush=False
+                    )
+
                 # Turn on spectrograph corrections
                 if atspectrograph:
                     logger.debug("Enabling atspectrograph and hexapod corrections")
@@ -833,7 +872,14 @@ class TestCSC(unittest.TestCase):
                     )
 
                     pointingOffsetSummary = await harness.aos_remote.evt_pointingOffsetSummary.next(
-                        flush=False, timeout=STD_TIMEOUT
+                        flush=False, timeout=STD_TIMEOUT * 2
+                    )
+                    # check atspectrograph corrections were applied
+                    await harness.aos_remote.evt_atspectrographCorrectionCompleted.next(
+                        timeout=STD_TIMEOUT, flush=False
+                    )
+                    await harness.aos_remote.evt_atspectrographCorrectionStarted.next(
+                        timeout=STD_TIMEOUT, flush=False
                     )
 
                 # check corrections were applied
@@ -913,6 +959,8 @@ class TestCSC(unittest.TestCase):
                         atspectrograph=True, hexapod=True
                     )
 
+                # Wait for corrections to be applied
+                await asyncio.sleep(4)
                 logger.debug(
                     "Try to apply an offset without the correction on, this should fail."
                 )
@@ -920,6 +968,16 @@ class TestCSC(unittest.TestCase):
                     await harness.aos_remote.cmd_offset.set_start(
                         **offset2, timeout=STD_TIMEOUT
                     )
+
+                offset_applied = await harness.aos_remote.evt_correctionOffsets.aget()
+                focusOffsetSummary = (
+                    await harness.aos_remote.evt_focusOffsetSummary.aget()
+                )
+
+                logger.debug(
+                    f"Before offset, focusOffsetSummary is {focusOffsetSummary}"
+                )
+                logger.debug(f"Before offset, offset_applied is {offset_applied}")
 
                 # flush events then send relative offsets
                 harness.aos_remote.evt_correctionOffsets.flush()
@@ -963,6 +1021,10 @@ class TestCSC(unittest.TestCase):
                     focusOffsetSummary.total, getattr(offset_applied, "z")
                 )
                 # userApplied offset should just be whatever we supplied
+                logger.debug(
+                    f"Checking assertions. focusOffsetSummary is {focusOffsetSummary}"
+                )
+                logger.debug(f"Checking assertions. offset_applied is {offset_applied}")
                 self.assertAlmostEqual(focusOffsetSummary.userApplied, offset["z"])
                 self.assertAlmostEqual(focusOffsetSummary.filter, filter_focus_offset)
                 self.assertAlmostEqual(
@@ -977,6 +1039,8 @@ class TestCSC(unittest.TestCase):
                     harness.aos_remote.evt_correctionOffsets.flush()
                     harness.aos_remote.evt_focusOffsetSummary.flush()
                     harness.aos_remote.evt_pointingOffsetSummary.flush()
+                    harness.aos_remote.evt_atspectrographCorrectionStarted.flush()
+                    harness.aos_remote.evt_atspectrographCorrectionCompleted.flush()
 
                     harness.atspectrograph.evt_reportedFilterPosition.set_put(
                         name=filter_name2,
@@ -985,14 +1049,14 @@ class TestCSC(unittest.TestCase):
                         pointingOffsets=filter_pointing_offsets2,
                     )
 
-                    await harness.aos_remote.evt_atspectrographCorrectionStarted.aget(
-                        timeout=STD_TIMEOUT
+                    await harness.aos_remote.evt_atspectrographCorrectionStarted.next(
+                        timeout=STD_TIMEOUT, flush=False
                     )
-                    await harness.aos_remote.evt_atspectrographCorrectionCompleted.aget(
-                        timeout=STD_TIMEOUT
+                    await harness.aos_remote.evt_atspectrographCorrectionCompleted.next(
+                        timeout=STD_TIMEOUT, flush=False
                     )
                     # check pointing offset was applied
-                    harness.atptg.cmd_offsetAzEl.callback.assert_called()
+                    harness.atptg.cmd_poriginOffset.callback.assert_called()
 
                     # check focus model updates were applied
                     offset_applied = await harness.aos_remote.evt_correctionOffsets.next(
@@ -1058,6 +1122,8 @@ class TestCSC(unittest.TestCase):
                     harness.aos_remote.evt_correctionOffsets.flush()
                     harness.aos_remote.evt_focusOffsetSummary.flush()
                     harness.aos_remote.evt_pointingOffsetSummary.flush()
+                    harness.aos_remote.evt_atspectrographCorrectionStarted.flush()
+                    harness.aos_remote.evt_atspectrographCorrectionCompleted.flush()
 
                     harness.atspectrograph.evt_reportedDisperserPosition.set_put(
                         name=disperser_name2,
@@ -1065,14 +1131,14 @@ class TestCSC(unittest.TestCase):
                         pointingOffsets=disperser_pointing_offsets2,
                     )
 
-                    await harness.aos_remote.evt_atspectrographCorrectionStarted.aget(
-                        timeout=STD_TIMEOUT
+                    await harness.aos_remote.evt_atspectrographCorrectionStarted.next(
+                        timeout=STD_TIMEOUT, flush=False
                     )
-                    await harness.aos_remote.evt_atspectrographCorrectionCompleted.aget(
-                        timeout=STD_TIMEOUT
+                    await harness.aos_remote.evt_atspectrographCorrectionCompleted.next(
+                        timeout=STD_TIMEOUT, flush=False
                     )
                     # check pointing offset was applied
-                    harness.atptg.cmd_offsetAzEl.callback.assert_called()
+                    harness.atptg.cmd_poriginOffset.callback.assert_called()
 
                     offset_applied = await harness.aos_remote.evt_correctionOffsets.next(
                         flush=False, timeout=STD_TIMEOUT
@@ -1183,6 +1249,19 @@ class TestCSC(unittest.TestCase):
                 )
 
                 if atspectrograph:
+                    # Verify that no spectrograph specific offset took place
+                    logger.debug(
+                        "Make sure spectrograph correction is not "
+                        "applied, so this should fail"
+                    )
+                    with self.assertRaises(asyncio.TimeoutError):
+                        await harness.aos_remote.evt_atspectrographCorrectionStarted.next(
+                            timeout=STD_TIMEOUT, flush=False
+                        )
+                    with self.assertRaises(asyncio.TimeoutError):
+                        await harness.aos_remote.evt_atspectrographCorrectionCompleted.next(
+                            timeout=STD_TIMEOUT, flush=False
+                        )
                     # Check pointingOffsets is correct, but note they are
                     # arrays. Must loop over values individually
                     for n in range(len(pointingOffsetSummary.total) - 1):
@@ -1268,7 +1347,7 @@ class TestCSC(unittest.TestCase):
                     wraps=hexapod_move_callback
                 )
                 harness.aos_remote.evt_detailedState.callback = Mock(wraps=callback)
-                harness.atptg.cmd_offsetAzEl.callback = Mock(
+                harness.atptg.cmd_poriginOffset.callback = Mock(
                     wraps=mount_offset_callback
                 )
 
@@ -1317,6 +1396,20 @@ class TestCSC(unittest.TestCase):
                     settingsToApply="current",
                     timeout=60,
                 )
+
+                logger.debug(
+                    "Make sure spectrograph correction is not "
+                    "applied, so this should fail"
+                )
+                with self.assertRaises(asyncio.TimeoutError):
+                    await harness.aos_remote.evt_atspectrographCorrectionStarted.next(
+                        timeout=STD_TIMEOUT, flush=False
+                    )
+                with self.assertRaises(asyncio.TimeoutError):
+                    await harness.aos_remote.evt_atspectrographCorrectionCompleted.next(
+                        timeout=STD_TIMEOUT, flush=False
+                    )
+
                 self.assertEqual(harness.csc.summary_state, salobj.State.ENABLED)
 
                 # send elevation/azimuth positions
@@ -1353,6 +1446,9 @@ class TestCSC(unittest.TestCase):
                 logger.debug("Send new central wavelength with loop closed.")
                 harness.aos_remote.evt_correctionOffsets.flush()
                 harness.aos_remote.evt_focusOffsetSummary.flush()
+                harness.aos_remote.evt_atspectrographCorrectionStarted.flush()
+                harness.aos_remote.evt_atspectrographCorrectionCompleted.flush()
+
                 await harness.aos_remote.cmd_setWavelength.set_start(
                     wavelength=new_cen_wave
                 )
@@ -1371,6 +1467,13 @@ class TestCSC(unittest.TestCase):
                 # check corrections were applied
                 correctionOffsets = await harness.aos_remote.evt_correctionOffsets.aget(
                     timeout=STD_TIMEOUT
+                )
+                # check correction started/completed events were sent
+                await harness.aos_remote.evt_atspectrographCorrectionStarted.next(
+                    timeout=STD_TIMEOUT, flush=False
+                )
+                await harness.aos_remote.evt_atspectrographCorrectionCompleted.next(
+                    timeout=STD_TIMEOUT, flush=False
                 )
                 # check focus accounting is being done correctly
                 focusOffsetSummary = await harness.aos_remote.evt_focusOffsetSummary.aget(
@@ -1478,6 +1581,8 @@ class TestCSC(unittest.TestCase):
                 harness.aos_remote.evt_correctionOffsets.flush()
                 harness.aos_remote.evt_focusOffsetSummary.flush()
                 harness.aos_remote.evt_pointingOffsetSummary.flush()
+                harness.aos_remote.evt_atspectrographCorrectionStarted.flush()
+                harness.aos_remote.evt_atspectrographCorrectionCompleted.flush()
 
                 harness.atspectrograph.evt_reportedFilterPosition.set_put(
                     name=filter_name2,
@@ -1487,14 +1592,20 @@ class TestCSC(unittest.TestCase):
                 )
 
                 # Timeouts extended as filter/disperser changes can take ~5s
-                await harness.aos_remote.evt_atspectrographCorrectionStarted.aget(
-                    timeout=STD_TIMEOUT * 2
+                await harness.aos_remote.evt_atspectrographCorrectionStarted.next(
+                    timeout=STD_TIMEOUT * 2, flush=False
                 )
-                await harness.aos_remote.evt_atspectrographCorrectionCompleted.aget(
-                    timeout=STD_TIMEOUT
+                await harness.aos_remote.evt_atspectrographCorrectionCompleted.next(
+                    timeout=STD_TIMEOUT, flush=False
                 )
                 # check pointing offset was applied
-                harness.atptg.cmd_offsetAzEl.callback.assert_called()
+                harness.atptg.cmd_poriginOffset.callback.assert_called()
+                # Should have only been called once
+                offset_call_count_filt2 = (
+                    harness.atptg.cmd_poriginOffset.callback.call_count
+                )
+                # FIXME
+                logger.debug(f"offset_call_count_filt2 is {offset_call_count_filt2}")
 
                 # check focus model updates were applied
                 offset_applied = await harness.aos_remote.evt_correctionOffsets.next(
@@ -1537,11 +1648,15 @@ class TestCSC(unittest.TestCase):
                 # wavelength offset should now be zero!
                 self.assertAlmostEqual(focusOffsetSummary.wavelength, focus_wave_expect)
 
+                await asyncio.sleep(3)
+
                 # flush events then change dispersers
                 logger.debug("Putting in disperser2")
                 harness.aos_remote.evt_correctionOffsets.flush()
                 harness.aos_remote.evt_focusOffsetSummary.flush()
                 harness.aos_remote.evt_pointingOffsetSummary.flush()
+                harness.aos_remote.evt_atspectrographCorrectionStarted.flush()
+                harness.aos_remote.evt_atspectrographCorrectionCompleted.flush()
 
                 harness.atspectrograph.evt_reportedDisperserPosition.set_put(
                     name=disperser_name2,
@@ -1549,14 +1664,20 @@ class TestCSC(unittest.TestCase):
                     pointingOffsets=disperser_pointing_offsets2,
                 )
                 # extended timeouts as filter/disperser changes takes ~5s
-                await harness.aos_remote.evt_atspectrographCorrectionStarted.aget(
-                    timeout=STD_TIMEOUT * 2
+                await harness.aos_remote.evt_atspectrographCorrectionStarted.next(
+                    timeout=STD_TIMEOUT * 2, flush=False
                 )
-                await harness.aos_remote.evt_atspectrographCorrectionCompleted.aget(
-                    timeout=STD_TIMEOUT
+                await harness.aos_remote.evt_atspectrographCorrectionCompleted.next(
+                    timeout=STD_TIMEOUT, flush=False
                 )
                 # check pointing offset was applied
-                harness.atptg.cmd_offsetAzEl.callback.assert_called()
+                offset_call_count_disp2 = (
+                    harness.atptg.cmd_poriginOffset.callback.call_count
+                )
+                logger.debug(
+                    f"offset_call_count_disp2 is now {offset_call_count_disp2}"
+                )
+                self.assertGreater(offset_call_count_disp2, offset_call_count_filt2)
 
                 offset_applied = await harness.aos_remote.evt_correctionOffsets.next(
                     flush=False, timeout=STD_TIMEOUT * 2
@@ -1596,6 +1717,54 @@ class TestCSC(unittest.TestCase):
                 )
                 # should be zero!
                 self.assertAlmostEqual(focusOffsetSummary.wavelength, focus_wave_expect)
+
+                # Now put in a filter that results in zero changes required
+                # to the telescope setup, but make sure events are all
+                # re-published.
+                logger.debug("Putting in filter2b, which is filter2 again")
+                # flush events then change filters
+                # wavelength offset should now go to zero
+                harness.aos_remote.evt_correctionOffsets.flush()
+                harness.aos_remote.evt_focusOffsetSummary.flush()
+                harness.aos_remote.evt_pointingOffsetSummary.flush()
+                harness.aos_remote.evt_atspectrographCorrectionStarted.flush()
+                harness.aos_remote.evt_atspectrographCorrectionCompleted.flush()
+
+                harness.atspectrograph.evt_reportedFilterPosition.set_put(
+                    name=filter_name2,
+                    centralWavelength=filter_central_wavelength2,
+                    focusOffset=filter_focus_offset2,
+                    pointingOffsets=filter_pointing_offsets2,
+                    force_output=True,  # Must force since it's the same event
+                )
+
+                # Timeouts extended as filter/disperser changes can take ~5s
+                await harness.aos_remote.evt_atspectrographCorrectionStarted.next(
+                    timeout=STD_TIMEOUT * 2, flush=False
+                )
+                await harness.aos_remote.evt_atspectrographCorrectionCompleted.next(
+                    timeout=STD_TIMEOUT, flush=False
+                )
+                # check pointing offset was *NOT* applied since no
+                # changes were made
+                offset_call_count_filt2b = (
+                    harness.atptg.cmd_poriginOffset.callback.call_count
+                )
+                self.assertEqual(offset_call_count_filt2b, offset_call_count_disp2)
+
+                # check focus model updates were applied
+                offset_applied2 = await harness.aos_remote.evt_correctionOffsets.next(
+                    flush=False, timeout=STD_TIMEOUT
+                )
+                focusOffsetSummary2 = await harness.aos_remote.evt_focusOffsetSummary.next(
+                    flush=False, timeout=STD_TIMEOUT
+                )
+
+                # check that summaries are unchanged
+                self.assertAlmostEqual(
+                    focusOffsetSummary.total, focusOffsetSummary2.total
+                )
+                self.assertAlmostEqual(offset_applied.z, offset_applied2.z)
 
                 # Now reset the offsets (after flushing events), can only
                 # reset offsets for hexapod loop as it's the only one enabled
@@ -1726,7 +1895,7 @@ class TestCSC(unittest.TestCase):
                 harness.hexapod.cmd_moveToPosition.callback = Mock(
                     wraps=hexapod_move_callback
                 )
-                harness.atptg.cmd_offsetAzEl.callback = Mock(
+                harness.atptg.cmd_poriginOffset.callback = Mock(
                     wraps=mount_offset_callback
                 )
 
@@ -1858,22 +2027,22 @@ class TestCSC(unittest.TestCase):
                                 timeout=STD_TIMEOUT
                             )
                         elif corr == "hexapod":
-                            await harness.aos_remote.evt_hexapodCorrectionStarted.aget(
-                                timeout=STD_TIMEOUT
+                            await harness.aos_remote.evt_hexapodCorrectionStarted.next(
+                                timeout=STD_TIMEOUT, flush=False
                             )
                             harness.hexapod.cmd_moveToPosition.callback.assert_called()
-                            await harness.aos_remote.evt_hexapodCorrectionCompleted.aget(
-                                timeout=STD_TIMEOUT
+                            await harness.aos_remote.evt_hexapodCorrectionCompleted.next(
+                                timeout=STD_TIMEOUT, flush=False
                             )
                         elif corr == "atspectrograph":
-                            await harness.aos_remote.evt_atspectrographCorrectionStarted.aget(
-                                timeout=STD_TIMEOUT
+                            await harness.aos_remote.evt_atspectrographCorrectionStarted.next(
+                                timeout=STD_TIMEOUT, flush=False
                             )
-                            await harness.aos_remote.evt_atspectrographCorrectionCompleted.aget(
-                                timeout=STD_TIMEOUT
+                            await harness.aos_remote.evt_atspectrographCorrectionCompleted.next(
+                                timeout=STD_TIMEOUT, flush=False
                             )
                             # check pointing offset was applied
-                            harness.atptg.cmd_offsetAzEl.callback.assert_called()
+                            harness.atptg.cmd_poriginOffset.callback.assert_called()
                             # check offsets were applied correctly
                             focusOffsetSummary = await harness.aos_remote.evt_focusOffsetSummary.next(
                                 flush=False, timeout=STD_TIMEOUT
@@ -2057,7 +2226,6 @@ class TestCSC(unittest.TestCase):
 
     def test_target_handling(self):
         """Test changing of targets to verify pressures are adjusted correctly
-
         """
 
         async def doit():


### PR DESCRIPTION
…ing/wavelength changes, regardless of if an actual correction is necessary. This is required so scripts will know when the ATAOS has finished all spectrograph corrections since a script does not know if an physical correction is required.