### PR TITLE
Flip detailed state bit back after hexapod correction completed, even…

### DIFF
--- a/python/lsst/ts/ataos/ataos_csc.py
+++ b/python/lsst/ts/ataos/ataos_csc.py
@@ -1850,7 +1850,10 @@ class ATAOS(ConfigurableCsc):
 
             if not apply_correction:
                 self.log.debug("All hexapod corrections inside tolerance. Skipping...")
-                # FIXME: Bit should be flipped back before returning
+                # Flip bit back before returning
+                await self.set_detailed_state(
+                    np.uint8(self.detailed_state ^ status_bit)
+                )
                 return
 
             evt_start_attr.set(elevation=elevation, azimuth=azimuth, **hexapod)
@@ -1872,6 +1875,7 @@ class ATAOS(ConfigurableCsc):
             finally:
                 await evt_end_attr.write()
                 # correction completed... flip bit on detailedState
+                # back to IDLE
                 await self.set_detailed_state(
                     np.uint8(self.detailed_state ^ status_bit)
                 )


### PR DESCRIPTION
… if the hexapod motion was below the threshold.